### PR TITLE
Add Internal Group Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ If Group Overrides are added for non managed groups, they will become managed an
 
  1. Import the attached Repository.
  2. Restore only the Lookup table first: RoleGroupOverrides
- 3. Update the Internal System to include the new RoleGroupOverrides table. 
- 4. On the Columns tab of the Internal-RoleGroupOverrides table, set the Key to the ID column, and the ExpiresOn datatype to Date. 
- 5. Restore everything else in the repository.
- 6. Grant access to the new app as needed.
+ 3. Update the Internal System to include the new RoleGroupOverrides table.
+ 4. On the Columns tab of the Internal RoleGroupOverrides table, set the Key to the ID column, and the ExpiresOn datatype to Date.
+ 5. On the Relations tab, relate the GroupID_Number to the 'groups' Internal table, and the MemberID_Number to the 'users' Internal table.
+ 6. Restore everything else in the repository.
+ 7. Grant access to the new app as needed.
 
  
 

--- a/RoleGroupOverride_Repository.json
+++ b/RoleGroupOverride_Repository.json
@@ -1,9 +1,9 @@
 {
-    "name": "RoleGroupOverrides_App_repo_20250630",
+    "name": "RoleGroupOverrides_App_repo_20251014",
     "type": "partial",
     "host": "DevNIM",
-    "created": 1751316521434,
-    "comment": "Role Group Override App - v4",
+    "created": 1760473384873,
+    "comment": "Role Group Override App - v5",
     "resources": [
         {
             "name": "internal.RoleGroupOverrides.GroupID-AD.Groups.objectGUID",
@@ -86,7 +86,54 @@
                         "enabled": true,
                         "index": 1,
                         "parent": 0,
+                        "child_count": 3
+                    },
+                    {
+                        "type": "and",
+                        "blocked": false,
+                        "id": "3fca0273-4cdb-4e30-a8ae-4825e3c94a46",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 2,
+                        "parent": 1,
                         "child_count": 2
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "groups",
+                        "field_n": "GroupID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Groups",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "9502631b-ff83-4bb8-9475-81c57bcdb7b6",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 3,
+                        "parent": 2,
+                        "child_count": 0
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "users",
+                        "field_n": "MemberID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Users",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "dfd9e5fc-1fa8-46c4-a895-7199c44bcf7b",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 4,
+                        "parent": 2,
+                        "child_count": 0
                     },
                     {
                         "type": "and",
@@ -95,7 +142,7 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 2,
+                        "index": 5,
                         "parent": 1,
                         "child_count": 2
                     },
@@ -116,8 +163,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 3,
-                        "parent": 2,
+                        "index": 6,
+                        "parent": 5,
                         "child_count": 0
                     },
                     {
@@ -137,8 +184,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 4,
-                        "parent": 2,
+                        "index": 7,
+                        "parent": 5,
                         "child_count": 0
                     },
                     {
@@ -148,7 +195,7 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 5,
+                        "index": 8,
                         "parent": 1,
                         "child_count": 2
                     },
@@ -169,8 +216,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 6,
-                        "parent": 5,
+                        "index": 9,
+                        "parent": 8,
                         "child_count": 0
                     },
                     {
@@ -190,8 +237,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 7,
-                        "parent": 5,
+                        "index": 10,
+                        "parent": 8,
                         "child_count": 0
                     }
                 ],
@@ -202,7 +249,7 @@
                         "name": "cf_GroupName",
                         "display_name": "cf_GroupName",
                         "show": true,
-                        "javascript": "return data['AD_Groups'] && data['AD_Groups']['cn'] ? data['AD_Groups']['cn'] \n\t\t: data['G_Groups'] && data['G_Groups']['name'] ? data['G_Groups']['name']\n\t\t: '';",
+                        "javascript": "return data['AD_Groups'] && data['AD_Groups']['cn'] ? data['AD_Groups']['cn'] \n\t\t: data['G_Groups'] && data['G_Groups']['name'] ? data['G_Groups']['name']\n        : data['NIM_Groups'] && data['NIM_Groups']['Name'] ? data['NIM_Groups']['Name']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -211,7 +258,7 @@
                         "name": "cf_MemberName",
                         "display_name": "cf_MemberName",
                         "show": true,
-                        "javascript": "return data['AD_Users'] && data['AD_Users']['displayName'] ? data['AD_Users']['displayName'] \n\t\t: data['G_Users'] && data['G_Users']['fullName'] ? data['G_Users']['fullName']\n\t\t: '';",
+                        "javascript": "return data['AD_Users'] && data['AD_Users']['displayName'] ? data['AD_Users']['displayName'] \n\t\t: data['G_Users'] && data['G_Users']['fullName'] ? data['G_Users']['fullName']\n        : data['NIM_Users'] && data['NIM_Users']['DisplayName'] ? data['NIM_Users']['DisplayName']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -220,7 +267,7 @@
                         "name": "cf_Username",
                         "display_name": "cf_Username",
                         "show": true,
-                        "javascript": "return data['AD_Users'] && data['AD_Users']['sAMAccountName'] ? data['AD_Users']['sAMAccountName'] \n\t\t: data['G_Users'] && data['G_Users']['primaryEmail'] ? data['G_Users']['primaryEmail']\n\t\t: '';",
+                        "javascript": "return data['AD_Users'] && data['AD_Users']['sAMAccountName'] ? data['AD_Users']['sAMAccountName'] \n\t\t: data['G_Users'] && data['G_Users']['primaryEmail'] ? data['G_Users']['primaryEmail']\n        : data['NIM_Users'] && data['NIM_Users']['Name'] ? data['NIM_Users']['Name']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -229,7 +276,7 @@
                         "name": "cf_System",
                         "display_name": "cf_System",
                         "show": true,
-                        "javascript": "return data['AD_Users']  ? 'AD'\n\t\t: data['G_Users']  ? 'Google'\n\t\t: '';",
+                        "javascript": "return data['AD_Users']  ? 'AD'\n\t\t: data['G_Users']  ? 'Google'\n        : data['NIM_Users'] ? 'NIM'\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -255,8 +302,17 @@
                         "source": "data"
                     },
                     {
-                        "id": "RoleGroupOverrides.MemberID",
+                        "id": "cf_GroupID_Number",
                         "order": 7,
+                        "name": "cf_GroupID_Number",
+                        "display_name": "GroupID_Number",
+                        "show": true,
+                        "javascript": "// Special logic since Number Fields don't like NULL or empty values (they default to 0)\nreturn data['RoleGroupOverrides']['GroupID_Number'] ? data['RoleGroupOverrides']['GroupID_Number'] : null;;",
+                        "source": "script"
+                    },
+                    {
+                        "id": "RoleGroupOverrides.MemberID",
+                        "order": 8,
                         "name": "RoleGroupOverrides.MemberID",
                         "display_name": "MemberID",
                         "show": true,
@@ -266,8 +322,17 @@
                         "source": "data"
                     },
                     {
+                        "id": "cf_MemberID_Number",
+                        "order": 9,
+                        "name": "cf_MemberID_Number",
+                        "display_name": "MemberID_Number",
+                        "show": true,
+                        "javascript": "// Special logic since NIM doens't like NULL or empty Number fields in lookup.\nreturn data['RoleGroupOverrides']['MemberID_Number'] ? data['RoleGroupOverrides']['MemberID_Number'] : null;",
+                        "source": "script"
+                    },
+                    {
                         "id": "RoleGroupOverrides.ExpiresOn",
-                        "order": 8,
+                        "order": 10,
                         "name": "RoleGroupOverrides.ExpiresOn",
                         "display_name": "ExpiresOn",
                         "show": true,
@@ -278,7 +343,7 @@
                     },
                     {
                         "id": "RoleGroupOverrides.Notes",
-                        "order": 9,
+                        "order": 11,
                         "name": "RoleGroupOverrides.Notes",
                         "display_name": "Notes",
                         "show": true,
@@ -307,9 +372,9 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319352,
+                    "created_date_time": 1758650448926,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315456025,
+                    "modified_date_time": 1759786615131,
                     "modified_by_id": 2,
                     "notes": "Provides data to Audit Query used in main app grid, list of groups with overrides.",
                     "tags": [
@@ -340,7 +405,7 @@
                         "child_count": 1
                     },
                     {
-                        "type": "or",
+                        "type": "and",
                         "blocked": false,
                         "id": "cf369cd9-42bf-433d-bc20-ed61b59481b9",
                         "indent": 1,
@@ -348,40 +413,6 @@
                         "enabled": true,
                         "index": 1,
                         "parent": 0,
-                        "child_count": 2
-                    },
-                    {
-                        "field_name": "path",
-                        "function_name": "contains (ci)",
-                        "value_vs_parameter": true,
-                        "param_name": "",
-                        "operand_value": "OU=District,DC",
-                        "param_expression": false,
-                        "type": "expression",
-                        "blocked": false,
-                        "id": "66ec1c2e-e0aa-4423-bc93-fd446af3a940",
-                        "indent": 2,
-                        "inherited": false,
-                        "enabled": true,
-                        "index": 2,
-                        "parent": 1,
-                        "child_count": 0
-                    },
-                    {
-                        "field_name": "path",
-                        "function_name": "contains (ci)",
-                        "value_vs_parameter": true,
-                        "param_name": "",
-                        "operand_value": "OU=Schools,DC",
-                        "param_expression": false,
-                        "type": "expression",
-                        "blocked": false,
-                        "id": "7769be25-463d-4a9d-a646-adae835fd3b1",
-                        "indent": 2,
-                        "inherited": false,
-                        "enabled": true,
-                        "index": 3,
-                        "parent": 1,
                         "child_count": 0
                     }
                 ],
@@ -412,6 +443,15 @@
                         "show": true,
                         "javascript": "return 'AD';",
                         "source": "script"
+                    },
+                    {
+                        "id": "cf_GroupKey",
+                        "order": 4,
+                        "name": "cf_GroupKey",
+                        "display_name": "cf_GroupKey",
+                        "show": true,
+                        "javascript": "return '' + data['Groups']['objectGUID'];",
+                        "source": "script"
                     }
                 ],
                 "sort_columns": [
@@ -428,10 +468,6 @@
                 "params": [
                 ],
                 "appends": [
-                    {
-                        "filter_name": "App_RoleGroupOverrides-GroupsDD-Google",
-                        "enabled": true
-                    }
                 ],
                 "exclude": {
                     "enabled": false,
@@ -441,9 +477,9 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319356,
+                    "created_date_time": 1758650448927,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315490307,
+                    "modified_date_time": 1759786836118,
                     "modified_by_id": 2,
                     "notes": "Used in Group Dropdown when adding a new override.  Other systems should be appended to this filter.",
                     "tags": [
@@ -501,6 +537,15 @@
                         "show": true,
                         "javascript": "return 'Google';",
                         "source": "script"
+                    },
+                    {
+                        "id": "cf_GroupKey",
+                        "order": 4,
+                        "name": "cf_GroupKey",
+                        "display_name": "cf_GroupKey",
+                        "show": true,
+                        "javascript": "return '' + data['groups']['id'];",
+                        "source": "script"
                     }
                 ],
                 "sort_columns": [
@@ -522,13 +567,123 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319357,
+                    "created_date_time": 1758650448928,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315568821,
+                    "modified_date_time": 1759786931116,
                     "modified_by_id": 2,
                     "notes": "Sub filter appends to the AD filter.",
                     "tags": [
                         "app_RoleGroupOverrides"
+                    ]
+                }
+            },
+            "processValue": 0
+        },
+        {
+            "name": "App_RoleGroupOverrides-GroupsDD-NIM",
+            "category": 3,
+            "data": {
+                "filter_name": "App_RoleGroupOverrides-GroupsDD-NIM",
+                "filter_name_parent": "",
+                "filter_items": [
+                    {
+                        "system_name": "internal",
+                        "col_name": "groups",
+                        "colrefname": "groups",
+                        "type": "start",
+                        "blocked": false,
+                        "id": "ce135f9b-c42b-420d-864b-ed557e211090",
+                        "indent": 0,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 0,
+                        "child_count": 0
+                    }
+                ],
+                "filter_columns": [
+                    {
+                        "id": "cf_GroupKey",
+                        "order": 1,
+                        "name": "cf_GroupKey",
+                        "display_name": "cf_GroupKey",
+                        "show": true,
+                        "javascript": "// Either GroupID or GroupID_Number.  Needed for DropDown, thus needs to be a String.\nreturn '' + data['groups']['ID'];",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_GroupID",
+                        "order": 2,
+                        "name": "cf_GroupID",
+                        "display_name": "cf_GroupID",
+                        "show": true,
+                        "javascript": "return null;",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_GroupID_Number",
+                        "order": 3,
+                        "name": "cf_GroupID_Number",
+                        "display_name": "cf_GroupID_Number",
+                        "show": true,
+                        "javascript": "return data['groups']['ID'];",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_GroupName",
+                        "order": 4,
+                        "name": "cf_GroupName",
+                        "display_name": "cf_GroupName",
+                        "show": true,
+                        "javascript": "return data['groups']['Name'] + ' (NIM)';",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_System",
+                        "order": 5,
+                        "name": "cf_System",
+                        "display_name": "cf_System",
+                        "show": true,
+                        "javascript": "return 'NIM';",
+                        "source": "script"
+                    }
+                ],
+                "sort_columns": [
+                    {
+                        "name": "cf_GroupName",
+                        "ascending": true
+                    }
+                ],
+                "group": {
+                    "enabled": false,
+                    "count": 1,
+                    "field": "cf_GroupKey"
+                },
+                "params": [
+                ],
+                "appends": [
+                    {
+                        "filter_name": "App_RoleGroupOverrides-GroupsDD-AD",
+                        "enabled": true
+                    },
+                    {
+                        "filter_name": "App_RoleGroupOverrides-GroupsDD-Google",
+                        "enabled": true
+                    }
+                ],
+                "exclude": {
+                    "enabled": false,
+                    "field_name": "",
+                    "exclude_after_oas": false
+                },
+                "lookups": [
+                ],
+                "meta_config": {
+                    "created_date_time": 1759336356843,
+                    "created_by_id": 2,
+                    "modified_date_time": 1759854208829,
+                    "modified_by_id": 2,
+                    "notes": "",
+                    "tags": [
                     ]
                 }
             },
@@ -563,8 +718,18 @@
                         "enabled": true,
                         "index": 1,
                         "parent": 0,
-                        "child_count": 2,
-                        "parentId": "cd178399-1974-41fb-8bad-c06145c1606c"
+                        "child_count": 2
+                    },
+                    {
+                        "type": "or",
+                        "blocked": false,
+                        "id": "16675c03-b852-4ddf-a9bb-7228841f047c",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 2,
+                        "parent": 1,
+                        "child_count": 2
                     },
                     {
                         "field_name": "GroupID",
@@ -574,14 +739,29 @@
                         "param_expression": false,
                         "type": "expression",
                         "blocked": false,
-                        "id": "0bd41ac4-d28b-443a-9d50-caaee4fc33e3",
-                        "indent": 2,
+                        "id": "209c051e-a3ea-4c3c-8ec1-fb9bacb386e3",
+                        "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 2,
-                        "parent": 1,
-                        "child_count": 0,
-                        "parentId": "32cdeb1c-079e-4a12-aab7-a2b58c928893"
+                        "index": 3,
+                        "parent": 2,
+                        "child_count": 0
+                    },
+                    {
+                        "field_name": "GroupID_Number",
+                        "function_name": "equals",
+                        "value_vs_parameter": false,
+                        "param_name": "GroupID_Number",
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "d25dffd5-d485-49ae-b0b9-9c6de305ddc1",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 4,
+                        "parent": 2,
+                        "child_count": 0
                     },
                     {
                         "type": "or",
@@ -590,10 +770,56 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 3,
+                        "index": 5,
                         "parent": 1,
-                        "child_count": 2,
-                        "parentId": "32cdeb1c-079e-4a12-aab7-a2b58c928893"
+                        "child_count": 3
+                    },
+                    {
+                        "type": "and",
+                        "blocked": false,
+                        "id": "bd4af4c2-7b26-4f8a-ada4-18fee71a25de",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 6,
+                        "parent": 5,
+                        "child_count": 2
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "groups",
+                        "field_n": "GroupID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Groups",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "ad744e70-8ea1-4a50-a193-db9a59c40440",
+                        "indent": 4,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 7,
+                        "parent": 6,
+                        "child_count": 0
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "users",
+                        "field_n": "MemberID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Users",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "d49181cf-b59c-42c8-a2e6-0417c8aeef53",
+                        "indent": 4,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 8,
+                        "parent": 6,
+                        "child_count": 0
                     },
                     {
                         "type": "and",
@@ -602,10 +828,9 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 4,
-                        "parent": 3,
-                        "child_count": 2,
-                        "parentId": "78eb55e7-5399-4a05-b52f-a2bf4cfcd2d4"
+                        "index": 9,
+                        "parent": 5,
+                        "child_count": 2
                     },
                     {
                         "ref_type": "n-n",
@@ -624,10 +849,9 @@
                         "indent": 4,
                         "inherited": false,
                         "enabled": true,
-                        "index": 5,
-                        "parent": 4,
-                        "child_count": 0,
-                        "parentId": "1508b4d6-fbda-44a9-b536-ec735b72e6c0"
+                        "index": 10,
+                        "parent": 9,
+                        "child_count": 0
                     },
                     {
                         "ref_type": "n-n",
@@ -646,10 +870,9 @@
                         "indent": 4,
                         "inherited": false,
                         "enabled": true,
-                        "index": 6,
-                        "parent": 4,
-                        "child_count": 0,
-                        "parentId": "1508b4d6-fbda-44a9-b536-ec735b72e6c0"
+                        "index": 11,
+                        "parent": 9,
+                        "child_count": 0
                     },
                     {
                         "type": "and",
@@ -658,10 +881,9 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 7,
-                        "parent": 3,
-                        "child_count": 2,
-                        "parentId": "78eb55e7-5399-4a05-b52f-a2bf4cfcd2d4"
+                        "index": 12,
+                        "parent": 5,
+                        "child_count": 2
                     },
                     {
                         "ref_type": "n-n",
@@ -680,10 +902,9 @@
                         "indent": 4,
                         "inherited": false,
                         "enabled": true,
-                        "index": 8,
-                        "parent": 7,
-                        "child_count": 0,
-                        "parentId": "d58a0c92-074a-4b40-8e2a-964e528d973e"
+                        "index": 13,
+                        "parent": 12,
+                        "child_count": 0
                     },
                     {
                         "ref_type": "n-n",
@@ -702,10 +923,9 @@
                         "indent": 4,
                         "inherited": false,
                         "enabled": true,
-                        "index": 9,
-                        "parent": 7,
-                        "child_count": 0,
-                        "parentId": "d58a0c92-074a-4b40-8e2a-964e528d973e"
+                        "index": 14,
+                        "parent": 12,
+                        "child_count": 0
                     }
                 ],
                 "filter_columns": [
@@ -715,7 +935,7 @@
                         "name": "cf_GroupName",
                         "display_name": "cf_GroupName",
                         "show": true,
-                        "javascript": "return data['AD_Groups'] && data['AD_Groups']['cn'] ? data['AD_Groups']['cn'] \n\t\t: data['G_Groups'] && data['G_Groups']['name'] ? data['G_Groups']['name']\n\t\t: '';",
+                        "javascript": "return data['AD_Groups'] && data['AD_Groups']['cn'] ? data['AD_Groups']['cn'] \n\t\t: data['G_Groups'] && data['G_Groups']['name'] ? data['G_Groups']['name']\n        : data['NIM_Groups'] && data['NIM_Groups']['Name'] ? data['NIM_Groups']['Name']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -724,7 +944,7 @@
                         "name": "cf_MemberName",
                         "display_name": "cf_MemberName",
                         "show": true,
-                        "javascript": "return data['AD_Users'] && data['AD_Users']['displayName'] ? data['AD_Users']['displayName'] \n\t\t: data['G_Users'] && data['G_Users']['fullName'] ? data['G_Users']['fullName']\n\t\t: '';",
+                        "javascript": "return data['AD_Users'] && data['AD_Users']['displayName'] ? data['AD_Users']['displayName'] \n\t\t: data['G_Users'] && data['G_Users']['fullName'] ? data['G_Users']['fullName']\n        : data['NIM_Users'] && data['NIM_Users']['DisplayName'] ? data['NIM_Users']['DisplayName']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -733,7 +953,7 @@
                         "name": "cf_Username",
                         "display_name": "cf_Username",
                         "show": true,
-                        "javascript": "return data['AD_Users'] && data['AD_Users']['sAMAccountName'] ? data['AD_Users']['sAMAccountName'] \n\t\t: data['G_Users'] && data['G_Users']['primaryEmail'] ? data['G_Users']['primaryEmail']\n\t\t: '';",
+                        "javascript": "return data['AD_Users'] && data['AD_Users']['sAMAccountName'] ? data['AD_Users']['sAMAccountName'] \n\t\t: data['G_Users'] && data['G_Users']['primaryEmail'] ? data['G_Users']['primaryEmail']\n        : data['NIM_Users'] && data['NIM_Users']['Name'] ? data['NIM_Users']['Name']\n\t\t: '';",
                         "source": "script"
                     },
                     {
@@ -759,8 +979,19 @@
                         "source": "data"
                     },
                     {
-                        "id": "RoleGroupOverrides.MemberID",
+                        "id": "RoleGroupOverrides.GroupID_Number",
                         "order": 6,
+                        "name": "RoleGroupOverrides.GroupID_Number",
+                        "display_name": "GroupID_Number",
+                        "show": true,
+                        "field_name": "GroupID_Number",
+                        "colrefname": "RoleGroupOverrides",
+                        "nullable": false,
+                        "source": "data"
+                    },
+                    {
+                        "id": "RoleGroupOverrides.MemberID",
+                        "order": 7,
                         "name": "RoleGroupOverrides.MemberID",
                         "display_name": "MemberID",
                         "show": true,
@@ -770,8 +1001,19 @@
                         "source": "data"
                     },
                     {
+                        "id": "RoleGroupOverrides.MemberID_Number",
+                        "order": 8,
+                        "name": "RoleGroupOverrides.MemberID_Number",
+                        "display_name": "MemberID_Number",
+                        "show": true,
+                        "field_name": "MemberID_Number",
+                        "colrefname": "RoleGroupOverrides",
+                        "nullable": false,
+                        "source": "data"
+                    },
+                    {
                         "id": "RoleGroupOverrides.ExpiresOn",
-                        "order": 7,
+                        "order": 9,
                         "name": "RoleGroupOverrides.ExpiresOn",
                         "display_name": "ExpiresOn",
                         "show": true,
@@ -782,7 +1024,7 @@
                     },
                     {
                         "id": "RoleGroupOverrides.Notes",
-                        "order": 8,
+                        "order": 10,
                         "name": "RoleGroupOverrides.Notes",
                         "display_name": "Notes",
                         "show": true,
@@ -807,6 +1049,14 @@
                         "default_value": "",
                         "description": "",
                         "variable_name": ""
+                    },
+                    {
+                        "param_name": "GroupID_Number",
+                        "param_category": "input",
+                        "data_type": "number",
+                        "default_value": "100000000",
+                        "description": "",
+                        "variable_name": ""
                     }
                 ],
                 "appends": [
@@ -819,9 +1069,9 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319360,
+                    "created_date_time": 1758650448929,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315560426,
+                    "modified_date_time": 1759771285549,
                     "modified_by_id": 2,
                     "notes": "Used in grid showing the list of override users for the selected group.",
                     "tags": [
@@ -863,6 +1113,17 @@
                         "child_count": 2
                     },
                     {
+                        "type": "or",
+                        "blocked": false,
+                        "id": "ec13c4c6-ad64-47eb-9123-0c7f0e9e209c",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 2,
+                        "parent": 1,
+                        "child_count": 2
+                    },
+                    {
                         "field_name": "GroupID",
                         "function_name": "equals (ci)",
                         "value_vs_parameter": false,
@@ -870,12 +1131,28 @@
                         "param_expression": false,
                         "type": "expression",
                         "blocked": false,
-                        "id": "13dc02c9-13a8-4388-90fe-69534dd054fb",
-                        "indent": 2,
+                        "id": "3bbedfba-0aaf-459e-9a25-fa285ee0fd81",
+                        "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 2,
-                        "parent": 1,
+                        "index": 3,
+                        "parent": 2,
+                        "child_count": 0
+                    },
+                    {
+                        "field_name": "GroupID_Number",
+                        "function_name": "equals",
+                        "value_vs_parameter": false,
+                        "param_name": "GroupID_Number",
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "b3285926-2e9c-427e-a58c-4e4a15e02079",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 4,
+                        "parent": 2,
                         "child_count": 0
                     },
                     {
@@ -885,9 +1162,27 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 3,
+                        "index": 5,
                         "parent": 1,
-                        "child_count": 2
+                        "child_count": 3
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "users",
+                        "field_n": "MemberID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Users",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "2b6a9402-e409-455a-9b81-0047a55977b8",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 6,
+                        "parent": 5,
+                        "child_count": 0
                     },
                     {
                         "ref_type": "n-n",
@@ -906,8 +1201,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 4,
-                        "parent": 3,
+                        "index": 7,
+                        "parent": 5,
                         "child_count": 0
                     },
                     {
@@ -927,8 +1222,8 @@
                         "indent": 3,
                         "inherited": false,
                         "enabled": true,
-                        "index": 5,
-                        "parent": 3,
+                        "index": 8,
+                        "parent": 5,
                         "child_count": 0
                     }
                 ],
@@ -956,12 +1251,12 @@
                         "source": "data"
                     },
                     {
-                        "id": "RoleGroupOverrides.MemberID",
+                        "id": "RoleGroupOverrides.GroupID_Number",
                         "order": 3,
-                        "name": "RoleGroupOverrides.MemberID",
-                        "display_name": "MemberID",
+                        "name": "RoleGroupOverrides.GroupID_Number",
+                        "display_name": "GroupID_Number",
                         "show": true,
-                        "field_name": "MemberID",
+                        "field_name": "GroupID_Number",
                         "colrefname": "RoleGroupOverrides",
                         "nullable": false,
                         "source": "data"
@@ -1000,646 +1295,8 @@
                         "source": "data"
                     },
                     {
-                        "id": "AD_Users.accountExpires",
-                        "order": 7,
-                        "name": "AD_Users.accountExpires",
-                        "display_name": "accountExpires",
-                        "show": true,
-                        "field_name": "accountExpires",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.adminDescription",
-                        "order": 8,
-                        "name": "AD_Users.adminDescription",
-                        "display_name": "adminDescription",
-                        "show": true,
-                        "field_name": "adminDescription",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.adminDisplayName",
-                        "order": 9,
-                        "name": "AD_Users.adminDisplayName",
-                        "display_name": "adminDisplayName",
-                        "show": true,
-                        "field_name": "adminDisplayName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.c",
-                        "order": 10,
-                        "name": "AD_Users.c",
-                        "display_name": "c",
-                        "show": true,
-                        "field_name": "c",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.CannotChangePassword",
-                        "order": 11,
-                        "name": "AD_Users.CannotChangePassword",
-                        "display_name": "CannotChangePassword",
-                        "show": true,
-                        "field_name": "CannotChangePassword",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.canonicalName",
-                        "order": 12,
-                        "name": "AD_Users.canonicalName",
-                        "display_name": "canonicalName",
-                        "show": true,
-                        "field_name": "canonicalName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.ChangePasswordAtLogon",
-                        "order": 13,
-                        "name": "AD_Users.ChangePasswordAtLogon",
-                        "display_name": "ChangePasswordAtLogon",
-                        "show": true,
-                        "field_name": "ChangePasswordAtLogon",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.cn",
-                        "order": 14,
-                        "name": "AD_Users.cn",
-                        "display_name": "cn",
-                        "show": true,
-                        "field_name": "cn",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.co",
-                        "order": 15,
-                        "name": "AD_Users.co",
-                        "display_name": "co",
-                        "show": true,
-                        "field_name": "co",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.company",
-                        "order": 16,
-                        "name": "AD_Users.company",
-                        "display_name": "company",
-                        "show": true,
-                        "field_name": "company",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.countryCode",
-                        "order": 17,
-                        "name": "AD_Users.countryCode",
-                        "display_name": "countryCode",
-                        "show": true,
-                        "field_name": "countryCode",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.createTimeStamp",
-                        "order": 18,
-                        "name": "AD_Users.createTimeStamp",
-                        "display_name": "createTimeStamp",
-                        "show": true,
-                        "field_name": "createTimeStamp",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.department",
-                        "order": 19,
-                        "name": "AD_Users.department",
-                        "display_name": "department",
-                        "show": true,
-                        "field_name": "department",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.description",
-                        "order": 20,
-                        "name": "AD_Users.description",
-                        "display_name": "description",
-                        "show": true,
-                        "field_name": "description",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.displayName",
-                        "order": 21,
-                        "name": "AD_Users.displayName",
-                        "display_name": "displayName",
-                        "show": true,
-                        "field_name": "displayName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.distinguishedName",
-                        "order": 22,
-                        "name": "AD_Users.distinguishedName",
-                        "display_name": "distinguishedName",
-                        "show": true,
-                        "field_name": "distinguishedName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.division",
-                        "order": 23,
-                        "name": "AD_Users.division",
-                        "display_name": "division",
-                        "show": true,
-                        "field_name": "division",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.employeeID",
-                        "order": 24,
-                        "name": "AD_Users.employeeID",
-                        "display_name": "employeeID",
-                        "show": true,
-                        "field_name": "employeeID",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.employeeNumber",
-                        "order": 25,
-                        "name": "AD_Users.employeeNumber",
-                        "display_name": "employeeNumber",
-                        "show": true,
-                        "field_name": "employeeNumber",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.employeeType",
-                        "order": 26,
-                        "name": "AD_Users.employeeType",
-                        "display_name": "employeeType",
-                        "show": true,
-                        "field_name": "employeeType",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.Enabled",
-                        "order": 27,
-                        "name": "AD_Users.Enabled",
-                        "display_name": "Enabled",
-                        "show": true,
-                        "field_name": "Enabled",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.givenName",
-                        "order": 28,
-                        "name": "AD_Users.givenName",
-                        "display_name": "givenName",
-                        "show": true,
-                        "field_name": "givenName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.homeDirectory",
-                        "order": 29,
-                        "name": "AD_Users.homeDirectory",
-                        "display_name": "homeDirectory",
-                        "show": true,
-                        "field_name": "homeDirectory",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.homeDrive",
-                        "order": 30,
-                        "name": "AD_Users.homeDrive",
-                        "display_name": "homeDrive",
-                        "show": true,
-                        "field_name": "homeDrive",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.homePhone",
-                        "order": 31,
-                        "name": "AD_Users.homePhone",
-                        "display_name": "homePhone",
-                        "show": true,
-                        "field_name": "homePhone",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.initials",
-                        "order": 32,
-                        "name": "AD_Users.initials",
-                        "display_name": "initials",
-                        "show": true,
-                        "field_name": "initials",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.info",
-                        "order": 33,
-                        "name": "AD_Users.info",
-                        "display_name": "info",
-                        "show": true,
-                        "field_name": "info",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.ipPhone",
-                        "order": 34,
-                        "name": "AD_Users.ipPhone",
-                        "display_name": "ipPhone",
-                        "show": true,
-                        "field_name": "ipPhone",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.l",
-                        "order": 35,
-                        "name": "AD_Users.l",
-                        "display_name": "l",
-                        "show": true,
-                        "field_name": "l",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.lastLogon",
-                        "order": 36,
-                        "name": "AD_Users.lastLogon",
-                        "display_name": "lastLogon",
-                        "show": true,
-                        "field_name": "lastLogon",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.mail",
-                        "order": 37,
-                        "name": "AD_Users.mail",
-                        "display_name": "mail",
-                        "show": true,
-                        "field_name": "mail",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.manager",
-                        "order": 38,
-                        "name": "AD_Users.manager",
-                        "display_name": "manager",
-                        "show": true,
-                        "field_name": "manager",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.middleName",
-                        "order": 39,
-                        "name": "AD_Users.middleName",
-                        "display_name": "middleName",
-                        "show": true,
-                        "field_name": "middleName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.mobile",
-                        "order": 40,
-                        "name": "AD_Users.mobile",
-                        "display_name": "mobile",
-                        "show": true,
-                        "field_name": "mobile",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.name",
-                        "order": 41,
-                        "name": "AD_Users.name",
-                        "display_name": "name",
-                        "show": true,
-                        "field_name": "name",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.objectClass",
-                        "order": 42,
-                        "name": "AD_Users.objectClass",
-                        "display_name": "objectClass",
-                        "show": true,
-                        "field_name": "objectClass",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.objectSid",
-                        "order": 43,
-                        "name": "AD_Users.objectSid",
-                        "display_name": "objectSid",
-                        "show": true,
-                        "field_name": "objectSid",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.pager",
-                        "order": 44,
-                        "name": "AD_Users.pager",
-                        "display_name": "pager",
-                        "show": true,
-                        "field_name": "pager",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.PasswordExpirationDate",
-                        "order": 45,
-                        "name": "AD_Users.PasswordExpirationDate",
-                        "display_name": "PasswordExpirationDate",
-                        "show": true,
-                        "field_name": "PasswordExpirationDate",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.PasswordNeverExpires",
-                        "order": 46,
-                        "name": "AD_Users.PasswordNeverExpires",
-                        "display_name": "PasswordNeverExpires",
-                        "show": true,
-                        "field_name": "PasswordNeverExpires",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.PasswordNotRequired",
-                        "order": 47,
-                        "name": "AD_Users.PasswordNotRequired",
-                        "display_name": "PasswordNotRequired",
-                        "show": true,
-                        "field_name": "PasswordNotRequired",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.path",
-                        "order": 48,
-                        "name": "AD_Users.path",
-                        "display_name": "path",
-                        "show": true,
-                        "field_name": "path",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.physicalDeliveryOfficeName",
-                        "order": 49,
-                        "name": "AD_Users.physicalDeliveryOfficeName",
-                        "display_name": "physicalDeliveryOfficeName",
-                        "show": true,
-                        "field_name": "physicalDeliveryOfficeName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.postalCode",
-                        "order": 50,
-                        "name": "AD_Users.postalCode",
-                        "display_name": "postalCode",
-                        "show": true,
-                        "field_name": "postalCode",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.postOfficeBox",
-                        "order": 51,
-                        "name": "AD_Users.postOfficeBox",
-                        "display_name": "postOfficeBox",
-                        "show": true,
-                        "field_name": "postOfficeBox",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.profilePath",
-                        "order": 52,
-                        "name": "AD_Users.profilePath",
-                        "display_name": "profilePath",
-                        "show": true,
-                        "field_name": "profilePath",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.proxyAddresses",
-                        "order": 53,
-                        "name": "AD_Users.proxyAddresses",
-                        "display_name": "proxyAddresses",
-                        "show": true,
-                        "field_name": "proxyAddresses",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.roomNumber",
-                        "order": 54,
-                        "name": "AD_Users.roomNumber",
-                        "display_name": "roomNumber",
-                        "show": true,
-                        "field_name": "roomNumber",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.sAMAccountName",
-                        "order": 55,
-                        "name": "AD_Users.sAMAccountName",
-                        "display_name": "sAMAccountName",
-                        "show": true,
-                        "field_name": "sAMAccountName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.scriptPath",
-                        "order": 56,
-                        "name": "AD_Users.scriptPath",
-                        "display_name": "scriptPath",
-                        "show": true,
-                        "field_name": "scriptPath",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.sn",
-                        "order": 57,
-                        "name": "AD_Users.sn",
-                        "display_name": "sn",
-                        "show": true,
-                        "field_name": "sn",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.st",
-                        "order": 58,
-                        "name": "AD_Users.st",
-                        "display_name": "st",
-                        "show": true,
-                        "field_name": "st",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.streetAddress",
-                        "order": 59,
-                        "name": "AD_Users.streetAddress",
-                        "display_name": "streetAddress",
-                        "show": true,
-                        "field_name": "streetAddress",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.telephoneNumber",
-                        "order": 60,
-                        "name": "AD_Users.telephoneNumber",
-                        "display_name": "telephoneNumber",
-                        "show": true,
-                        "field_name": "telephoneNumber",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.title",
-                        "order": 61,
-                        "name": "AD_Users.title",
-                        "display_name": "title",
-                        "show": true,
-                        "field_name": "title",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.userPrincipalName",
-                        "order": 62,
-                        "name": "AD_Users.userPrincipalName",
-                        "display_name": "userPrincipalName",
-                        "show": true,
-                        "field_name": "userPrincipalName",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.whenCreated",
-                        "order": 63,
-                        "name": "AD_Users.whenCreated",
-                        "display_name": "whenCreated",
-                        "show": true,
-                        "field_name": "whenCreated",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "AD_Users.wWWHomePage",
-                        "order": 64,
-                        "name": "AD_Users.wWWHomePage",
-                        "display_name": "wWWHomePage",
-                        "show": true,
-                        "field_name": "wWWHomePage",
-                        "colrefname": "AD_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
                         "id": "G_Users.id",
-                        "order": 65,
+                        "order": 7,
                         "name": "G_Users.id",
                         "display_name": "G_Users.id",
                         "show": true,
@@ -1649,211 +1306,13 @@
                         "source": "data"
                     },
                     {
-                        "id": "G_Users.primaryEmail",
-                        "order": 66,
-                        "name": "G_Users.primaryEmail",
-                        "display_name": "primaryEmail",
+                        "id": "NIM_Users.ID",
+                        "order": 8,
+                        "name": "NIM_Users.ID",
+                        "display_name": "NIM_Users.ID",
                         "show": true,
-                        "field_name": "primaryEmail",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.isAdmin",
-                        "order": 67,
-                        "name": "G_Users.isAdmin",
-                        "display_name": "isAdmin",
-                        "show": true,
-                        "field_name": "isAdmin",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.suspended",
-                        "order": 68,
-                        "name": "G_Users.suspended",
-                        "display_name": "suspended",
-                        "show": true,
-                        "field_name": "suspended",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.changePasswordAtNextLogin",
-                        "order": 69,
-                        "name": "G_Users.changePasswordAtNextLogin",
-                        "display_name": "changePasswordAtNextLogin",
-                        "show": true,
-                        "field_name": "changePasswordAtNextLogin",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.fullName",
-                        "order": 70,
-                        "name": "G_Users.fullName",
-                        "display_name": "fullName",
-                        "show": true,
-                        "field_name": "fullName",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.familyName",
-                        "order": 71,
-                        "name": "G_Users.familyName",
-                        "display_name": "familyName",
-                        "show": true,
-                        "field_name": "familyName",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.givenName",
-                        "order": 72,
-                        "name": "G_Users.givenName",
-                        "display_name": "G_Users.givenName",
-                        "show": true,
-                        "field_name": "givenName",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.aliases",
-                        "order": 73,
-                        "name": "G_Users.aliases",
-                        "display_name": "aliases",
-                        "show": true,
-                        "field_name": "aliases",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.isMailboxSetup",
-                        "order": 74,
-                        "name": "G_Users.isMailboxSetup",
-                        "display_name": "isMailboxSetup",
-                        "show": true,
-                        "field_name": "isMailboxSetup",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.lastLoginTime",
-                        "order": 75,
-                        "name": "G_Users.lastLoginTime",
-                        "display_name": "lastLoginTime",
-                        "show": true,
-                        "field_name": "lastLoginTime",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.includeInGlobalAddressList",
-                        "order": 76,
-                        "name": "G_Users.includeInGlobalAddressList",
-                        "display_name": "includeInGlobalAddressList",
-                        "show": true,
-                        "field_name": "includeInGlobalAddressList",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.customSchemas_Tools4ever_ID",
-                        "order": 77,
-                        "name": "G_Users.customSchemas_Tools4ever_ID",
-                        "display_name": "customSchemas_Tools4ever_ID",
-                        "show": true,
-                        "field_name": "customSchemas_Tools4ever_ID",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.customSchemas_Tools4ever_Type",
-                        "order": 78,
-                        "name": "G_Users.customSchemas_Tools4ever_Type",
-                        "display_name": "customSchemas_Tools4ever_Type",
-                        "show": true,
-                        "field_name": "customSchemas_Tools4ever_Type",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.orgUnitPath",
-                        "order": 79,
-                        "name": "G_Users.orgUnitPath",
-                        "display_name": "orgUnitPath",
-                        "show": true,
-                        "field_name": "orgUnitPath",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.emails",
-                        "order": 80,
-                        "name": "G_Users.emails",
-                        "display_name": "emails",
-                        "show": true,
-                        "field_name": "emails",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.externalIds",
-                        "order": 81,
-                        "name": "G_Users.externalIds",
-                        "display_name": "externalIds",
-                        "show": true,
-                        "field_name": "externalIds",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.organizations",
-                        "order": 82,
-                        "name": "G_Users.organizations",
-                        "display_name": "organizations",
-                        "show": true,
-                        "field_name": "organizations",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.phones",
-                        "order": 83,
-                        "name": "G_Users.phones",
-                        "display_name": "phones",
-                        "show": true,
-                        "field_name": "phones",
-                        "colrefname": "G_Users",
-                        "nullable": false,
-                        "source": "data"
-                    },
-                    {
-                        "id": "G_Users.relations",
-                        "order": 84,
-                        "name": "G_Users.relations",
-                        "display_name": "relations",
-                        "show": true,
-                        "field_name": "relations",
-                        "colrefname": "G_Users",
+                        "field_name": "ID",
+                        "colrefname": "NIM_Users",
                         "nullable": false,
                         "source": "data"
                     }
@@ -1873,6 +1332,14 @@
                         "default_value": "",
                         "description": "",
                         "variable_name": ""
+                    },
+                    {
+                        "param_name": "GroupID_Number",
+                        "param_category": "input",
+                        "data_type": "number",
+                        "default_value": "",
+                        "description": "",
+                        "variable_name": ""
                     }
                 ],
                 "appends": [
@@ -1885,9 +1352,9 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319362,
+                    "created_date_time": 1758650448930,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315760743,
+                    "modified_date_time": 1759773763734,
                     "modified_by_id": 2,
                     "notes": "Membership filter used by Role Model.",
                     "tags": [
@@ -2102,10 +1569,6 @@
                     }
                 ],
                 "appends": [
-                    {
-                        "filter_name": "App_RoleGroupOverrides-MembersPending-Google",
-                        "enabled": true
-                    }
                 ],
                 "exclude": {
                     "enabled": false,
@@ -2115,9 +1578,9 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319367,
+                    "created_date_time": 1758650448932,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315623616,
+                    "modified_date_time": 1759340559565,
                     "modified_by_id": 2,
                     "notes": "Lists available users that do not have an override for the selected group.  Other systems users should be appended to this filter.",
                     "tags": [
@@ -2343,13 +1806,289 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319369,
+                    "created_date_time": 1758650448933,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315640304,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Sub filter appends to the MembersPending-AD filter.",
                     "tags": [
                         "app_RoleGroupOverrides"
+                    ]
+                }
+            },
+            "processValue": 0
+        },
+        {
+            "name": "App_RoleGroupOverrides-MembersPending-NIM",
+            "category": 3,
+            "data": {
+                "filter_name": "App_RoleGroupOverrides-MembersPending-NIM",
+                "filter_name_parent": "",
+                "filter_items": [
+                    {
+                        "system_name": "internal",
+                        "col_name": "users",
+                        "colrefname": "users",
+                        "type": "start",
+                        "blocked": false,
+                        "id": "488c01e3-f983-48a0-b8b1-7edce6b58ab7",
+                        "indent": 0,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 0,
+                        "child_count": 1
+                    },
+                    {
+                        "type": "and",
+                        "blocked": false,
+                        "id": "9829edba-0cc3-4dc0-820a-cc9d3f575d36",
+                        "indent": 1,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 1,
+                        "parent": 0,
+                        "child_count": 4
+                    },
+                    {
+                        "field_name": "ExternalID",
+                        "function_name": "exists",
+                        "value_vs_parameter": true,
+                        "param_name": "",
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "eaa08d8a-32cd-4f70-a61f-14bc57414f1a",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 2,
+                        "parent": 1,
+                        "child_count": 0
+                    },
+                    {
+                        "field_name": "Enabled",
+                        "function_name": "equals",
+                        "value_vs_parameter": true,
+                        "param_name": "",
+                        "operand_value": true,
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "82f95aa3-3cf4-4406-87b3-95ce46a27f8c",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 3,
+                        "parent": 1,
+                        "child_count": 0
+                    },
+                    {
+                        "ref_type": "1-n",
+                        "system_name_n": "internal",
+                        "col_name_n": "RoleGroupOverrides",
+                        "field_n": "MemberID_Number",
+                        "option": "no",
+                        "colrefname": "RoleGroupOverrides",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "a6394955-9df2-4901-9b2e-bcd8661d06ba",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 4,
+                        "parent": 1,
+                        "child_count": 1
+                    },
+                    {
+                        "type": "or",
+                        "blocked": false,
+                        "id": "34d90217-8bcc-4be0-b9cc-db6206d02958",
+                        "indent": 3,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 5,
+                        "parent": 4,
+                        "child_count": 2
+                    },
+                    {
+                        "field_name": "GroupID_Number",
+                        "function_name": "equals",
+                        "value_vs_parameter": false,
+                        "param_name": "GroupID_Number",
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "60a0bc6f-e29f-4d6d-a6a7-0795be8387f8",
+                        "indent": 4,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 6,
+                        "parent": 5,
+                        "child_count": 0
+                    },
+                    {
+                        "field_name": "GroupID",
+                        "function_name": "equals (ci)",
+                        "value_vs_parameter": false,
+                        "param_name": "GroupID",
+                        "param_expression": false,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "86f074ab-f5a2-4380-8f02-9ef92db665a6",
+                        "indent": 4,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 7,
+                        "parent": 5,
+                        "child_count": 0
+                    },
+                    {
+                        "field_name": "System",
+                        "function_name": "equals (ci)",
+                        "value_vs_parameter": true,
+                        "param_name": "System",
+                        "operand_value": "NIM",
+                        "param_expression": true,
+                        "type": "expression",
+                        "blocked": false,
+                        "id": "326aab31-a662-4029-9e46-7d5741fa1bb0",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 8,
+                        "parent": 1,
+                        "child_count": 0
+                    }
+                ],
+                "filter_columns": [
+                    {
+                        "id": "cf_MemberID",
+                        "order": 1,
+                        "name": "cf_MemberID",
+                        "display_name": "cf_MemberID",
+                        "show": true,
+                        "javascript": "return null;",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_MemberID_Number",
+                        "order": 2,
+                        "name": "cf_MemberID_Number",
+                        "display_name": "cf_MemberID_Number",
+                        "show": true,
+                        "javascript": "return data['users']['ID'];",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_MemberName",
+                        "order": 3,
+                        "name": "cf_MemberName",
+                        "display_name": "cf_MemberName",
+                        "show": true,
+                        "javascript": "return data['users']['DisplayName'];",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_MemberEmail",
+                        "order": 4,
+                        "name": "cf_MemberEmail",
+                        "display_name": "cf_MemberEmail",
+                        "show": true,
+                        "javascript": "return data['users']['Email'];",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_EmployeeID",
+                        "order": 5,
+                        "name": "cf_EmployeeID",
+                        "display_name": "cf_EmployeeID",
+                        "show": true,
+                        "javascript": "return null;",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_Type",
+                        "order": 6,
+                        "name": "cf_Type",
+                        "display_name": "cf_Type",
+                        "show": true,
+                        "javascript": "return null;",
+                        "source": "script"
+                    },
+                    {
+                        "id": "cf_System",
+                        "order": 7,
+                        "name": "cf_System",
+                        "display_name": "cf_System",
+                        "show": true,
+                        "javascript": "return 'NIM';",
+                        "source": "script"
+                    }
+                ],
+                "sort_columns": [
+                    {
+                        "name": "cf_MemberName",
+                        "ascending": true
+                    }
+                ],
+                "group": {
+                    "enabled": true,
+                    "count": 1,
+                    "field": "cf_MemberID_Number"
+                },
+                "params": [
+                    {
+                        "param_name": "GroupID",
+                        "param_category": "input",
+                        "data_type": "string",
+                        "default_value": "",
+                        "description": "",
+                        "inherited": false,
+                        "variable_name": ""
+                    },
+                    {
+                        "param_name": "System",
+                        "param_category": "input",
+                        "data_type": "string",
+                        "default_value": "NIM",
+                        "description": "",
+                        "inherited": false,
+                        "variable_name": ""
+                    },
+                    {
+                        "param_name": "GroupID_Number",
+                        "param_category": "input",
+                        "data_type": "number",
+                        "default_value": "100000000",
+                        "description": "",
+                        "variable_name": ""
+                    }
+                ],
+                "appends": [
+                    {
+                        "filter_name": "App_RoleGroupOverrides-MembersPending-Google",
+                        "enabled": true
+                    },
+                    {
+                        "filter_name": "App_RoleGroupOverrides-MembersPending-AD",
+                        "enabled": true
+                    }
+                ],
+                "exclude": {
+                    "enabled": false,
+                    "field_name": "",
+                    "exclude_after_oas": false
+                },
+                "lookups": [
+                ],
+                "meta_config": {
+                    "created_date_time": 1759337522363,
+                    "created_by_id": 2,
+                    "modified_date_time": 1759773593188,
+                    "modified_by_id": 2,
+                    "notes": "",
+                    "tags": [
                     ]
                 }
             },
@@ -2468,10 +2207,10 @@
                 "lookups": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319371,
+                    "created_date_time": 1758650448934,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315782601,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Mapping filter used to remove expired overrides.",
                     "tags": [
                         "app_RoleGroupOverrides"
@@ -2509,7 +2248,25 @@
                         "enabled": true,
                         "index": 1,
                         "parent": 0,
-                        "child_count": 2
+                        "child_count": 3
+                    },
+                    {
+                        "ref_type": "n-1",
+                        "system_name_1": "internal",
+                        "col_name_1": "groups",
+                        "field_n": "GroupID_Number",
+                        "option": "any",
+                        "colrefname": "NIM_Groups",
+                        "recursive": false,
+                        "type": "reference",
+                        "blocked": false,
+                        "id": "2b18f187-9c57-4033-8d85-57bba2897fd6",
+                        "indent": 2,
+                        "inherited": false,
+                        "enabled": true,
+                        "index": 2,
+                        "parent": 1,
+                        "child_count": 0
                     },
                     {
                         "ref_type": "n-n",
@@ -2528,7 +2285,7 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 2,
+                        "index": 3,
                         "parent": 1,
                         "child_count": 0
                     },
@@ -2549,7 +2306,7 @@
                         "indent": 2,
                         "inherited": false,
                         "enabled": true,
-                        "index": 3,
+                        "index": 4,
                         "parent": 1,
                         "child_count": 0
                     }
@@ -2561,7 +2318,7 @@
                         "name": "cf_RoleName",
                         "display_name": "cf_RoleName",
                         "show": true,
-                        "javascript": "let groupName = data['AD_Groups'] && data['AD_Groups']['cn'] ? 'AD_' + data['AD_Groups']['cn'] : 'Google_' + data['G_Groups']['name'];\ngroupName = groupName.replace(/\\W/g,'_');\nreturn 'RoleGroupOverride-' + groupName;",
+                        "javascript": "let groupName = \n      data['NIM_Groups'] ? 'NIM_' + data['NIM_Groups']['Name'] : \n      data['AD_Groups']  ? 'AD_' + data['AD_Groups']['cn'] : \n      data['G_Groups'] ? 'Google_' + data['G_Groups']['name'] :\n      'Unknown_';\n      \n// Replace Spaces with Underscores\ngroupName = groupName.replace(/\\W/g,'_');\n\n// Return Role Name\nreturn 'RoleGroupOverride-' + groupName;",
                         "source": "script"
                     },
                     {
@@ -2576,8 +2333,19 @@
                         "source": "data"
                     },
                     {
-                        "id": "RoleGroupOverrides.ExpiresOn",
+                        "id": "RoleGroupOverrides.GroupID_Number",
                         "order": 3,
+                        "name": "RoleGroupOverrides.GroupID_Number",
+                        "display_name": "GroupID_Number",
+                        "show": true,
+                        "field_name": "GroupID_Number",
+                        "colrefname": "RoleGroupOverrides",
+                        "nullable": false,
+                        "source": "data"
+                    },
+                    {
+                        "id": "RoleGroupOverrides.ExpiresOn",
+                        "order": 4,
                         "name": "RoleGroupOverrides.ExpiresOn",
                         "display_name": "ExpiresOn",
                         "show": true,
@@ -2585,6 +2353,15 @@
                         "colrefname": "RoleGroupOverrides",
                         "nullable": false,
                         "source": "data"
+                    },
+                    {
+                        "id": "cf_GroupName",
+                        "order": 5,
+                        "name": "cf_GroupName",
+                        "display_name": "cf_GroupName",
+                        "show": true,
+                        "javascript": "// Needed for NIM Group Lookups, because Lookups don't support NUMBER data types.\nreturn data['G_Groups'] ? data['G_Groups']['name'] :\n  data['AD_Groups'] ? data['AD_Groups']['cn'] :\n  data['NIM_Groups'] ? data['NIM_Groups']['Name'] : \n  'Invalid Name';",
+                        "source": "script"
                     }
                 ],
                 "sort_columns": [
@@ -2619,12 +2396,20 @@
                         "colName": "groups",
                         "fieldName": "id",
                         "includeVsExclude": true
+                    },
+                    {
+                        "lookupName": "NIM_Group",
+                        "filterColumnName": "cf_GroupName",
+                        "systemName": "internal",
+                        "colName": "groups",
+                        "fieldName": "Name",
+                        "includeVsExclude": true
                     }
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319372,
+                    "created_date_time": 1758650448935,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315820154,
+                    "modified_date_time": 1759774453361,
                     "modified_by_id": 2,
                     "notes": "Role Generator filter used to create roles for overridden groups.",
                     "tags": [
@@ -2669,10 +2454,10 @@
                 ],
                 "nimOnlyKey": false,
                 "meta_config": {
-                    "created_date_time": 1751315319375,
+                    "created_date_time": 1758650448936,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315904461,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Remove expired overrides.",
                     "tags": [
                         "app_RoleGroupOverrides"
@@ -2700,7 +2485,8 @@
                         "roleGeneratorFilterLookupName": "AD_Group",
                         "filterColumn": "objectGUID",
                         "membershipCol": "Memberships",
-                        "memberCol": "Users"
+                        "memberCol": "Users",
+                        "_processed": false
                     },
                     {
                         "enabledFlag": true,
@@ -2709,6 +2495,16 @@
                         "roleGeneratorFilterLookupName": "Google_Group",
                         "filterColumn": "G_Users.id",
                         "membershipCol": "members",
+                        "memberCol": "users",
+                        "_processed": false
+                    },
+                    {
+                        "enabledFlag": true,
+                        "systemName": "internal",
+                        "groupColName": "groups",
+                        "roleGeneratorFilterLookupName": "NIM_Group",
+                        "filterColumn": "NIM_Users.ID",
+                        "membershipCol": "memberships",
                         "memberCol": "users"
                     }
                 ],
@@ -2727,10 +2523,10 @@
             "data": {
                 "jobdef_name": "Internal_RoleGroupOverrides_DeleteExpired",
                 "meta_config": {
-                    "created_date_time": 1751315319381,
+                    "created_date_time": 1758650448938,
                     "created_by_id": 2,
-                    "modified_date_time": 1751315935020,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Remove expired overrides.",
                     "tags": [
                         "app_RoleGroupOverrides"
@@ -2753,7 +2549,7 @@
             "data": {
                 "type": "sync",
                 "name": "App_RoleGroupOverrides_DeleteExpired",
-                "enabled": true,
+                "enabled": false,
                 "schedule": {
                     "second": {
                         "mode": 1,
@@ -2799,10 +2595,10 @@
                     }
                 },
                 "meta_config": {
-                    "created_date_time": 1751315319382,
+                    "created_date_time": 1758650448940,
                     "created_by_id": 2,
-                    "modified_date_time": 1751316009724,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Remove expired overrides.",
                     "tags": [
                         "app_RoleGroupoOverrides"
@@ -2833,7 +2629,7 @@
             "data": {
                 "type": "role-generator",
                 "name": "App_RoleGroupOverrides_RoleGenerate",
-                "enabled": true,
+                "enabled": false,
                 "schedule": {
                     "second": {
                         "mode": 1,
@@ -2884,10 +2680,10 @@
                     }
                 },
                 "meta_config": {
-                    "created_date_time": 1751315319385,
+                    "created_date_time": 1758650448941,
                     "created_by_id": 2,
-                    "modified_date_time": 1751316049473,
-                    "modified_by_id": 2,
+                    "modified_date_time": 0,
+                    "modified_by_id": -1,
                     "notes": "Generate roles for defined Role Overrides.",
                     "tags": [
                         "app_RoleGroupoOverrides"
@@ -2911,7 +2707,7 @@
             "category": 19,
             "data": {
                 "name": "RoleGroupOverrides_GroupList",
-                "query": "SELECT\n\tcf_GroupName,\n    GroupID,\n    cf_System,\n    COUNT(MemberID) as MemberCount\nFROM f_App_RoleGroupOverrides_GroupList\nGROUP BY cf_GroupName,GroupID,cf_System\nORDER BY cf_GroupName\n",
+                "query": "SELECT\n\tcf_GroupName,\n    GroupID,\n    GroupID_Number,\n    cf_System,\n    COUNT(COALESCE(GroupID, GroupID_Number)) as MemberCount\nFROM f_App_RoleGroupOverrides_GroupList\nGROUP BY cf_GroupName,GroupID,GroupID_Number,cf_System\nORDER BY cf_GroupName\n",
                 "params": [
                 ],
                 "columns": [
@@ -2921,6 +2717,10 @@
                     },
                     {
                         "name": "GroupID",
+                        "type": 0
+                    },
+                    {
+                        "name": "GroupID_Number",
                         "type": 0
                     },
                     {
@@ -2951,6 +2751,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -2958,6 +2759,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 1,
@@ -2974,9 +2776,11 @@
                                         {
                                             "type": "column",
                                             "width": 8,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "Role Group Overrides",
                                                     "text_eval": {
                                                         "javascript": ""
@@ -2991,6 +2795,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "left",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 6,
@@ -3007,6 +2812,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3022,8 +2828,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -3033,6 +2843,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "right",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "app_name": "Dashboard",
@@ -3064,6 +2875,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3076,6 +2888,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 162,
@@ -3098,6 +2911,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3107,6 +2921,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 163,
@@ -3123,6 +2938,7 @@
                                         {
                                             "type": "column",
                                             "width": 4,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3131,6 +2947,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 165,
@@ -3147,6 +2964,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3162,8 +2980,14 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "caret-right",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": "caret-right",
+                                                        "colorSecondaryOpacity": 1,
+                                                        "family": "fad"
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -3173,6 +2997,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "type": "Navigate to form",
@@ -3205,12 +3030,14 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
                                                     "actions_description": "",
                                                     "actions_wait": true,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "type": "Set grid view",
@@ -3297,6 +3124,42 @@
                                                             },
                                                             "nav_mode": 3,
                                                             "form_name": "update_note"
+                                                        },
+                                                        {
+                                                            "system_name": "internal",
+                                                            "function_name": "RoleGroupOverrides_delete",
+                                                            "table_name": "RoleGroupOverrides",
+                                                            "description": "Remove Membership Override:  {grid_GroupName} -- Member: {grid_MemberName}",
+                                                            "event_generate": false,
+                                                            "hide_protected_data": true,
+                                                            "type": "Target system function execution",
+                                                            "event": {
+                                                                "type": "grid cell click",
+                                                                "column": "cc_remove",
+                                                                "view": "Members"
+                                                            },
+                                                            "arguments": [
+                                                                {
+                                                                    "allowance": 2,
+                                                                    "name": "ID",
+                                                                    "manual": false,
+                                                                    "data_type": 0,
+                                                                    "value_spec": {
+                                                                        "variable_name": "grid_ID",
+                                                                        "type": "variable"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_variables": [
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "Form initialize",
+                                                            "event": {
+                                                                "type": "grid cell click",
+                                                                "column": "cc_remove",
+                                                                "view": "Members"
+                                                            }
                                                         }
                                                     ],
                                                     "cid": 166,
@@ -3328,7 +3191,7 @@
                                                                         "column_show": true,
                                                                         "column_name": "cc_Handle",
                                                                         "column_type": 2,
-                                                                        "column_width": "20",
+                                                                        "column_width": 64,
                                                                         "data_type": 0,
                                                                         "display_name": " ",
                                                                         "variable_name": "",
@@ -3340,7 +3203,7 @@
                                                                         "column_show": true,
                                                                         "column_name": "cf_GroupName",
                                                                         "column_type": 0,
-                                                                        "column_width": 200,
+                                                                        "column_width": 154,
                                                                         "data_type": 0,
                                                                         "display_name": "GroupName",
                                                                         "variable_name": "grid_GroupName",
@@ -3352,10 +3215,22 @@
                                                                         "column_show": true,
                                                                         "column_name": "cf_System",
                                                                         "column_type": 0,
-                                                                        "column_width": 100,
+                                                                        "column_width": 103,
                                                                         "data_type": 0,
                                                                         "display_name": "System",
                                                                         "variable_name": "grid_System",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": true,
+                                                                        "column_name": "MemberCount",
+                                                                        "column_type": 0,
+                                                                        "column_width": 143,
+                                                                        "data_type": 0,
+                                                                        "display_name": "MemberCount",
+                                                                        "variable_name": "grid_MemberCount",
                                                                         "view_name": "",
                                                                         "key": false
                                                                     },
@@ -3373,13 +3248,13 @@
                                                                     },
                                                                     {
                                                                         "color": "",
-                                                                        "column_show": true,
-                                                                        "column_name": "MemberCount",
+                                                                        "column_show": false,
+                                                                        "column_name": "GroupID_Number",
                                                                         "column_type": 0,
-                                                                        "column_width": "140",
+                                                                        "column_width": 100,
                                                                         "data_type": 0,
-                                                                        "display_name": "MemberCount",
-                                                                        "variable_name": "grid_MemberCount",
+                                                                        "display_name": "GroupID_Number",
+                                                                        "variable_name": "grid_GroupID_Number",
                                                                         "view_name": "",
                                                                         "key": false
                                                                     }
@@ -3396,7 +3271,7 @@
                                                                     {
                                                                         "color": "",
                                                                         "column_show": true,
-                                                                        "column_name": "cc_Remove",
+                                                                        "column_name": "cc_remove",
                                                                         "column_type": 2,
                                                                         "column_width": 64,
                                                                         "data_type": 0,
@@ -3404,18 +3279,6 @@
                                                                         "variable_name": "",
                                                                         "view_name": "",
                                                                         "script": "let rowType = 'button';\nlet rowText = '';\nlet rowClass = 'btn badge btn-danger position-absolute top-50 start-50 translate-middle' ;\nlet rowIcon = 'eye-slash';\n\nreturn {\n  'type': rowType,\n  'text': rowText,\n  'class': rowClass,\n  'icon': rowIcon,\n  'style': { }\n}\n"
-                                                                    },
-                                                                    {
-                                                                        "color": "",
-                                                                        "column_show": false,
-                                                                        "column_name": "cf_GroupName",
-                                                                        "column_type": 0,
-                                                                        "column_width": 145,
-                                                                        "data_type": 0,
-                                                                        "display_name": "cf_GroupName",
-                                                                        "variable_name": "",
-                                                                        "view_name": "",
-                                                                        "key": false
                                                                     },
                                                                     {
                                                                         "color": "",
@@ -3443,42 +3306,6 @@
                                                                     },
                                                                     {
                                                                         "color": "",
-                                                                        "column_show": false,
-                                                                        "column_name": "RoleGroupOverrides.ID",
-                                                                        "column_type": 0,
-                                                                        "column_width": 189,
-                                                                        "data_type": 0,
-                                                                        "display_name": "RoleGroupOverrides.ID",
-                                                                        "variable_name": "grid_ID",
-                                                                        "view_name": "",
-                                                                        "key": false
-                                                                    },
-                                                                    {
-                                                                        "color": "",
-                                                                        "column_show": false,
-                                                                        "column_name": "GroupID",
-                                                                        "column_type": 0,
-                                                                        "column_width": 110,
-                                                                        "data_type": 0,
-                                                                        "display_name": "GroupID",
-                                                                        "variable_name": "",
-                                                                        "view_name": "",
-                                                                        "key": false
-                                                                    },
-                                                                    {
-                                                                        "color": "",
-                                                                        "column_show": false,
-                                                                        "column_name": "MemberID",
-                                                                        "column_type": 0,
-                                                                        "column_width": 122,
-                                                                        "data_type": 0,
-                                                                        "display_name": "MemberID",
-                                                                        "variable_name": "grid_MemberID",
-                                                                        "view_name": "",
-                                                                        "key": false
-                                                                    },
-                                                                    {
-                                                                        "color": "",
                                                                         "column_show": true,
                                                                         "column_name": "ExpiresOn",
                                                                         "column_type": 0,
@@ -3500,6 +3327,78 @@
                                                                         "variable_name": "grid_Notes",
                                                                         "view_name": "",
                                                                         "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "RoleGroupOverrides.ID",
+                                                                        "column_type": 0,
+                                                                        "column_width": 189,
+                                                                        "data_type": 0,
+                                                                        "display_name": "RoleGroupOverrides.ID",
+                                                                        "variable_name": "grid_ID",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "MemberID",
+                                                                        "column_type": 0,
+                                                                        "column_width": 122,
+                                                                        "data_type": 0,
+                                                                        "display_name": "MemberID",
+                                                                        "variable_name": "grid_MemberID",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "MemberID_Number",
+                                                                        "column_type": 0,
+                                                                        "column_width": 172,
+                                                                        "data_type": 1,
+                                                                        "display_name": "MemberID_Number",
+                                                                        "variable_name": "grid_MemberID_Number",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "cf_GroupName",
+                                                                        "column_type": 0,
+                                                                        "column_width": 145,
+                                                                        "data_type": 0,
+                                                                        "display_name": "cf_GroupName",
+                                                                        "variable_name": "",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "GroupID",
+                                                                        "column_type": 0,
+                                                                        "column_width": 110,
+                                                                        "data_type": 0,
+                                                                        "display_name": "GroupID",
+                                                                        "variable_name": "",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "GroupID_Number",
+                                                                        "column_type": 0,
+                                                                        "column_width": 160,
+                                                                        "data_type": 1,
+                                                                        "display_name": "GroupID_Number",
+                                                                        "variable_name": "",
+                                                                        "view_name": "",
+                                                                        "key": false
                                                                     }
                                                                 ],
                                                                 "params": [
@@ -3507,12 +3406,23 @@
                                                                         "param_name": "GroupID",
                                                                         "description": "",
                                                                         "data_type": 0,
+                                                                        "fixed_value": "01pxezwc2czuo4p",
+                                                                        "options_flag": false,
+                                                                        "options_values": [
+                                                                        ],
+                                                                        "variable_flag": true,
+                                                                        "variable_name": "v_GroupID"
+                                                                    },
+                                                                    {
+                                                                        "param_name": "GroupID_Number",
+                                                                        "description": "",
+                                                                        "data_type": 1,
                                                                         "fixed_value": "",
                                                                         "options_flag": false,
                                                                         "options_values": [
                                                                         ],
                                                                         "variable_flag": true,
-                                                                        "variable_name": "grid_GroupID"
+                                                                        "variable_name": "v_GroupID_Number"
                                                                     }
                                                                 ],
                                                                 "variable_input": "",
@@ -3543,9 +3453,11 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "WARNING - Only add Groups Managed by the NIM RoleModel.  Other groups will have all members removed except those defined here.",
                                                     "text_eval": {
                                                         "javascript": ""
@@ -3560,6 +3472,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 199,
@@ -3584,6 +3497,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3599,8 +3513,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -3610,6 +3528,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": true,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "type": "Form initialize",
@@ -3646,6 +3565,7 @@
                             "actions_description": "",
                             "actions_wait": false,
                             "alignment": "",
+                            "align_vertical": "",
                             "actions": [
                             ],
                             "cid": -1,
@@ -3666,6 +3586,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3673,6 +3594,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 174,
@@ -3689,9 +3611,11 @@
                                         {
                                             "type": "column",
                                             "width": 10,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "Add Override",
                                                     "text_eval": {
                                                         "javascript": ""
@@ -3706,6 +3630,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 177,
@@ -3730,6 +3655,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3742,6 +3668,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 178,
@@ -3764,6 +3691,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3779,8 +3707,20 @@
                                                     "option_values": "",
                                                     "table": {
                                                         "table_type": "filter",
-                                                        "table_name": "App_RoleGroupOverrides-GroupsDD-AD",
+                                                        "table_name": "App_RoleGroupOverrides-GroupsDD-NIM",
                                                         "columns": [
+                                                            {
+                                                                "color": "",
+                                                                "column_show": true,
+                                                                "column_name": "cf_GroupKey",
+                                                                "column_type": 0,
+                                                                "column_width": 50,
+                                                                "data_type": 0,
+                                                                "display_name": "cf_GroupKey",
+                                                                "variable_name": "dd_GroupKey",
+                                                                "view_name": "",
+                                                                "key": false
+                                                            },
                                                             {
                                                                 "color": "",
                                                                 "column_show": true,
@@ -3790,6 +3730,18 @@
                                                                 "data_type": 0,
                                                                 "display_name": "cf_GroupID",
                                                                 "variable_name": "dd_GroupID",
+                                                                "view_name": "",
+                                                                "key": false
+                                                            },
+                                                            {
+                                                                "color": "",
+                                                                "column_show": true,
+                                                                "column_name": "cf_GroupID_Number",
+                                                                "column_type": 0,
+                                                                "column_width": 50,
+                                                                "data_type": 0,
+                                                                "display_name": "cf_GroupID_Number",
+                                                                "variable_name": "dd_GroupID_Number",
                                                                 "view_name": "",
                                                                 "key": false
                                                             },
@@ -3825,12 +3777,13 @@
                                                     },
                                                     "table_flag": true,
                                                     "table_column_display": "cf_GroupName",
-                                                    "table_column_value": "cf_GroupID",
-                                                    "variable": "dd_GroupID",
-                                                    "variable_input": "grid_GroupID",
+                                                    "table_column_value": "cf_GroupKey",
+                                                    "variable": "dd_GroupKey",
+                                                    "variable_input": "",
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 179,
@@ -3861,9 +3814,11 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "Group...",
                                                     "text_eval": {
                                                         "javascript": "return 'Group - ' + data['grid_GroupName'];"
@@ -3878,6 +3833,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 187,
@@ -3902,6 +3858,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -3909,6 +3866,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 180,
@@ -3933,12 +3891,14 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 181,
@@ -3963,17 +3923,29 @@
                                                         "table_views": {
                                                             "default": {
                                                                 "table_type": "filter",
-                                                                "table_name": "App_RoleGroupOverrides-MembersPending-AD",
+                                                                "table_name": "App_RoleGroupOverrides-MembersPending-NIM",
                                                                 "columns": [
                                                                     {
                                                                         "color": "",
                                                                         "column_show": false,
                                                                         "column_name": "cf_MemberID",
                                                                         "column_type": 0,
-                                                                        "column_width": "100",
+                                                                        "column_width": 137,
                                                                         "data_type": 0,
                                                                         "display_name": "cf_MemberID",
                                                                         "variable_name": "gridNew_MemberID",
+                                                                        "view_name": "",
+                                                                        "key": false
+                                                                    },
+                                                                    {
+                                                                        "color": "",
+                                                                        "column_show": false,
+                                                                        "column_name": "cf_MemberID_Number",
+                                                                        "column_type": 0,
+                                                                        "column_width": 187,
+                                                                        "data_type": 0,
+                                                                        "display_name": "cf_MemberID_Number",
+                                                                        "variable_name": "gridNew_MemberID_Number",
                                                                         "view_name": "",
                                                                         "key": false
                                                                     },
@@ -3984,7 +3956,7 @@
                                                                         "column_type": 0,
                                                                         "column_width": "150",
                                                                         "data_type": 0,
-                                                                        "display_name": "Member Name",
+                                                                        "display_name": "Name",
                                                                         "variable_name": "gridNew_MemberName",
                                                                         "view_name": "",
                                                                         "key": false
@@ -3996,7 +3968,7 @@
                                                                         "column_type": 0,
                                                                         "column_width": "150",
                                                                         "data_type": 0,
-                                                                        "display_name": "MemberEmail",
+                                                                        "display_name": "Email",
                                                                         "variable_name": "gridNew_MemberEmail",
                                                                         "view_name": "",
                                                                         "key": false
@@ -4006,9 +3978,9 @@
                                                                         "column_show": true,
                                                                         "column_name": "cf_EmployeeID",
                                                                         "column_type": 0,
-                                                                        "column_width": "110",
+                                                                        "column_width": 144,
                                                                         "data_type": 0,
-                                                                        "display_name": "Emp/Stu ID",
+                                                                        "display_name": "EmployeeID",
                                                                         "variable_name": "gridNew_EmployeeID",
                                                                         "view_name": "",
                                                                         "key": false
@@ -4030,9 +4002,9 @@
                                                                         "column_show": false,
                                                                         "column_name": "cf_System",
                                                                         "column_type": 0,
-                                                                        "column_width": 100,
+                                                                        "column_width": "110",
                                                                         "data_type": 0,
-                                                                        "display_name": "cf_System",
+                                                                        "display_name": "System",
                                                                         "variable_name": "",
                                                                         "view_name": "",
                                                                         "key": false
@@ -4060,6 +4032,17 @@
                                                                         ],
                                                                         "variable_flag": true,
                                                                         "variable_name": "v_System"
+                                                                    },
+                                                                    {
+                                                                        "param_name": "GroupID_Number",
+                                                                        "description": "",
+                                                                        "data_type": 1,
+                                                                        "fixed_value": "",
+                                                                        "options_flag": false,
+                                                                        "options_values": [
+                                                                        ],
+                                                                        "variable_flag": true,
+                                                                        "variable_name": "v_GroupID_Number"
                                                                     }
                                                                 ],
                                                                 "variable_input": "",
@@ -4090,6 +4073,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4118,6 +4102,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 185,
@@ -4148,6 +4133,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4164,6 +4150,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 186,
@@ -4194,6 +4181,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4209,8 +4197,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -4220,6 +4212,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "variable": "ti_Notes",
@@ -4230,6 +4223,41 @@
                                                         },
                                                         {
                                                             "variable": "dt_ExpiresOn",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupKey",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupID",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupID_Number",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupName",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_System",
                                                             "type": "Reset variable",
                                                             "event": {
                                                                 "type": "button click"
@@ -4258,6 +4286,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4273,8 +4302,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -4284,6 +4317,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": true,
                                                     "alignment": "right",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "system_name": "internal",
@@ -4319,11 +4353,31 @@
                                                                 },
                                                                 {
                                                                     "allowance": 1,
+                                                                    "name": "GroupID_Number",
+                                                                    "manual": false,
+                                                                    "data_type": 1,
+                                                                    "value_spec": {
+                                                                        "variable_name": "v_GroupID_Number_null",
+                                                                        "type": "variable"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "allowance": 1,
                                                                     "name": "MemberID",
                                                                     "manual": false,
                                                                     "data_type": 0,
                                                                     "value_spec": {
                                                                         "variable_name": "gridNew_MemberID",
+                                                                        "type": "variable"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "allowance": 1,
+                                                                    "name": "MemberID_Number",
+                                                                    "manual": false,
+                                                                    "data_type": 1,
+                                                                    "value_spec": {
+                                                                        "variable_name": "v_MemberID_Number",
                                                                         "type": "variable"
                                                                     }
                                                                 },
@@ -4350,6 +4404,41 @@
                                                         },
                                                         {
                                                             "variable": "ti_Notes",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupKey",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupID",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupID_Number",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_GroupName",
+                                                            "type": "Reset variable",
+                                                            "event": {
+                                                                "type": "button click"
+                                                            }
+                                                        },
+                                                        {
+                                                            "variable": "dd_System",
                                                             "type": "Reset variable",
                                                             "event": {
                                                                 "type": "button click"
@@ -4398,6 +4487,7 @@
                             "actions_description": "",
                             "actions_wait": false,
                             "alignment": "",
+                            "align_vertical": "",
                             "actions": [
                             ],
                             "cid": -1,
@@ -4418,6 +4508,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4425,6 +4516,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 188,
@@ -4441,9 +4533,11 @@
                                         {
                                             "type": "column",
                                             "width": 10,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "Update Date",
                                                     "text_eval": {
                                                         "javascript": ""
@@ -4458,6 +4552,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 189,
@@ -4482,6 +4577,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4494,6 +4590,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 190,
@@ -4516,6 +4613,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4532,6 +4630,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 196,
@@ -4562,6 +4661,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4577,8 +4677,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -4588,6 +4692,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "variable": "dt_ExpiresOn",
@@ -4619,6 +4724,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4634,8 +4740,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -4645,6 +4755,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": true,
                                                     "alignment": "right",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "system_name": "internal",
@@ -4759,6 +4870,7 @@
                             "actions_description": "",
                             "actions_wait": false,
                             "alignment": "",
+                            "align_vertical": "",
                             "actions": [
                             ],
                             "cid": -1,
@@ -4779,6 +4891,7 @@
                                         {
                                             "type": "column",
                                             "width": 2,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4786,6 +4899,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 200,
@@ -4802,9 +4916,11 @@
                                         {
                                             "type": "column",
                                             "width": 10,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
+                                                    "color_default_flag": true,
                                                     "text_value": "Update Note",
                                                     "text_eval": {
                                                         "javascript": ""
@@ -4819,6 +4935,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 201,
@@ -4843,6 +4960,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4855,6 +4973,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 202,
@@ -4877,6 +4996,7 @@
                                         {
                                             "type": "column",
                                             "width": 12,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4905,6 +5025,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                     ],
                                                     "cid": 206,
@@ -4935,6 +5056,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -4950,8 +5072,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -4961,6 +5087,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": false,
                                                     "alignment": "",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "variable": "ti_Notes",
@@ -4992,6 +5119,7 @@
                                         {
                                             "type": "column",
                                             "width": 6,
+                                            "align_vertical": "",
                                             "cell": {
                                                 "type": "unit",
                                                 "unit": {
@@ -5007,8 +5135,12 @@
                                                         "javascript": ""
                                                     },
                                                     "fit_column": false,
-                                                    "icon_left": "",
-                                                    "icon_right": "",
+                                                    "icon_left": {
+                                                        "name": ""
+                                                    },
+                                                    "icon_right": {
+                                                        "name": ""
+                                                    },
                                                     "disable_form_invalid": false,
                                                     "default_button": false,
                                                     "pm_enabled": false,
@@ -5018,6 +5150,7 @@
                                                     "actions_description": "",
                                                     "actions_wait": true,
                                                     "alignment": "right",
+                                                    "align_vertical": "",
                                                     "actions": [
                                                         {
                                                             "system_name": "internal",
@@ -5132,6 +5265,7 @@
                             "actions_description": "",
                             "actions_wait": false,
                             "alignment": "",
+                            "align_vertical": "",
                             "actions": [
                             ],
                             "cid": -1,
@@ -5145,6 +5279,14 @@
                 ],
                 "props": {
                     "app_modern_theme": false,
+                    "categories": [
+                    ],
+                    "center_vertical": true,
+                    "color_settings_default": true,
+                    "color_background_dark": "#2b3035",
+                    "color_background_dark_opacity": 1,
+                    "color_background_light": "#f8f9fa",
+                    "color_background_light_opacity": 1,
                     "description": "Add Users to Role Managed Groups",
                     "display_name": "Role Group Overrides",
                     "image": "sitemap-solid.svg",
@@ -5153,9 +5295,16 @@
                     "onboarding_app": false,
                     "password_reset_app": false,
                     "xv_support": true,
+                    "background_image_light": {
+                        "default": true
+                    },
+                    "background_image_dark": {
+                        "default": true
+                    },
                     "actions_description": "",
                     "actions_wait": false,
                     "alignment": "",
+                    "align_vertical": "",
                     "actions": [
                     ],
                     "cid": -1,
@@ -5172,7 +5321,7 @@
                         "name": "v_GroupID",
                         "type": 1,
                         "javascript": {
-                            "javascript": "return data['grid_GroupID'] ?? data['dd_GroupID'];"
+                            "javascript": "let value = (data['grid_GroupID'] ?? data['dd_GroupID']);\nreturn value ? value : '';"
                         }
                     },
                     {
@@ -5195,6 +5344,34 @@
                         "javascript": {
                             "javascript": "return data['grid_ExpiresOn'] ? new Date(data['grid_ExpiresOn']) : '';"
                         }
+                    },
+                    {
+                        "name": "v_GroupID_Number",
+                        "type": 1,
+                        "javascript": {
+                            "javascript": "let value = (data['grid_GroupID_Number'] ?? data['dd_GroupID_Number']);\nreturn value ? value : '';"
+                        }
+                    },
+                    {
+                        "name": "v_MemberID_Number",
+                        "type": 1,
+                        "javascript": {
+                            "javascript": "return data['gridNew_MemberID_Number'] ? data['gridNew_MemberID_Number'] : null;"
+                        }
+                    },
+                    {
+                        "name": "v_GroupID_Number_null",
+                        "type": 1,
+                        "javascript": {
+                            "javascript": "let value = (data['grid_GroupID_Number'] ?? data['dd_GroupID_Number']);\nreturn value ? value : null;"
+                        }
+                    },
+                    {
+                        "name": "v_GroupKey",
+                        "type": 1,
+                        "javascript": {
+                            "javascript": "let GroupID = data['grid_GroupID'] ?? data['dd_GroupID'];\nlet GroupID_Number = data['grid_GroupID_Number'] ?? data['dd_GroupID_Number'];\n\nreturn GroupID ? GroupID : '' + GroupID_Number;"
+                        }
                     }
                 ],
                 "name_generator": {
@@ -5205,7 +5382,7 @@
                     "output_fields": [
                     ]
                 },
-                "nim_version": 1714,
+                "nim_version": 1778,
                 "password_generator": {
                     "name": "",
                     "input_fields": [
@@ -5216,36 +5393,34 @@
                 "valid_variables": [
                 ],
                 "meta_config": {
-                    "created_date_time": 1751315319389,
+                    "created_date_time": 1758650448944,
                     "created_by_id": 2,
-                    "modified_date_time": 0,
-                    "modified_by_id": -1,
+                    "modified_date_time": 1760112416268,
+                    "modified_by_id": 2,
                     "notes": "Add users to Groups managed by NIM, who don't normally qualify for the group.",
                     "tags": [
                         "nim"
                     ]
                 },
-                "stamp_ci_lib": 4,
+                "stamp_ci_lib": 0,
                 "syscol_app_tables": [
                     [
                         "internal.RoleGroupOverrides",
                         [
                             "filter.App_RoleGroupOverrides-MemberList",
-                            "filter.App_RoleGroupOverrides-MembersPending-AD"
+                            "filter.App_RoleGroupOverrides-MembersPending-NIM"
                         ]
                     ],
                     [
                         "AD.Users",
                         [
-                            "filter.App_RoleGroupOverrides-MemberList",
-                            "filter.App_RoleGroupOverrides-MembersPending-AD"
+                            "filter.App_RoleGroupOverrides-MemberList"
                         ]
                     ],
                     [
                         "AD.Groups",
                         [
-                            "filter.App_RoleGroupOverrides-MemberList",
-                            "filter.App_RoleGroupOverrides-GroupsDD-AD"
+                            "filter.App_RoleGroupOverrides-MemberList"
                         ]
                     ],
                     [
@@ -5259,7 +5434,23 @@
                         [
                             "filter.App_RoleGroupOverrides-MemberList"
                         ]
+                    ],
+                    [
+                        "internal.users",
+                        [
+                            "filter.App_RoleGroupOverrides-MemberList",
+                            "filter.App_RoleGroupOverrides-MembersPending-NIM"
+                        ]
+                    ],
+                    [
+                        "internal.groups",
+                        [
+                            "filter.App_RoleGroupOverrides-MemberList",
+                            "filter.App_RoleGroupOverrides-GroupsDD-NIM"
+                        ]
                     ]
+                ],
+                "varnames_svc_side": [
                 ]
             },
             "processValue": 0
@@ -5281,8 +5472,18 @@
                         "auto": false
                     },
                     {
+                        "name": "GroupID_Number",
+                        "type": 1,
+                        "auto": false
+                    },
+                    {
                         "name": "MemberID",
                         "type": 0,
+                        "auto": false
+                    },
+                    {
+                        "name": "MemberID_Number",
+                        "type": 1,
                         "auto": false
                     },
                     {
@@ -5296,16 +5497,15 @@
                         "auto": false
                     }
                 ],
-                "rows": [
-                    {
-                        "ID": "34f4847c-43a2-47b0-953f-0b6877da8122",
-                        "GroupID": "00abcd",
-                        "MemberID": "1234",
-                        "Notes": "Test"
-                    }
-                ],
+                "rows": [],
                 "rows_storage_disabled": false
             },
+            "processValue": 0
+        },
+        {
+            "name": "sitemap-solid.svg",
+            "category": 40,
+            "data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1NzYgNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZD0iTTIwOCA4MGMwLTI2LjUgMjEuNS00OCA0OC00OGw2NCAwYzI2LjUgMCA0OCAyMS41IDQ4IDQ4bDAgNjRjMCAyNi41LTIxLjUgNDgtNDggNDhsLTggMCAwIDQwIDE1MiAwYzMwLjkgMCA1NiAyNS4xIDU2IDU2bDAgMzIgOCAwYzI2LjUgMCA0OCAyMS41IDQ4IDQ4bDAgNjRjMCAyNi41LTIxLjUgNDgtNDggNDhsLTY0IDBjLTI2LjUgMC00OC0yMS41LTQ4LTQ4bDAtNjRjMC0yNi41IDIxLjUtNDggNDgtNDhsOCAwIDAtMzJjMC00LjQtMy42LTgtOC04bC0xNTIgMCAwIDQwIDggMGMyNi41IDAgNDggMjEuNSA0OCA0OGwwIDY0YzAgMjYuNS0yMS41IDQ4LTQ4IDQ4bC02NCAwYy0yNi41IDAtNDgtMjEuNS00OC00OGwwLTY0YzAtMjYuNSAyMS41LTQ4IDQ4LTQ4bDggMCAwLTQwLTE1MiAwYy00LjQgMC04IDMuNi04IDhsMCAzMiA4IDBjMjYuNSAwIDQ4IDIxLjUgNDggNDhsMCA2NGMwIDI2LjUtMjEuNSA0OC00OCA0OGwtNjQgMGMtMjYuNSAwLTQ4LTIxLjUtNDgtNDhsMC02NGMwLTI2LjUgMjEuNS00OCA0OC00OGw4IDAgMC0zMmMwLTMwLjkgMjUuMS01NiA1Ni01NmwxNTIgMCAwLTQwLTggMGMtMjYuNSAwLTQ4LTIxLjUtNDgtNDhsMC02NHoiLz48L3N2Zz4=",
             "processValue": 0
         }
     ],
@@ -5392,10 +5592,6 @@
                 "c": 3,
                 "childs": [
                     {
-                        "n": "App_RoleGroupOverrides-GroupsDD-Google",
-                        "c": 3
-                    },
-                    {
                         "n": "AD",
                         "c": 1
                     }
@@ -5407,6 +5603,42 @@
                 "childs": [
                     {
                         "n": "Google",
+                        "c": 1
+                    }
+                ]
+            },
+            {
+                "n": "App_RoleGroupOverrides-GroupsDD-NIM",
+                "c": 3,
+                "childs": [
+                    {
+                        "n": "App_RoleGroupOverrides-GroupsDD-AD",
+                        "c": 3
+                    },
+                    {
+                        "n": "App_RoleGroupOverrides-GroupsDD-Google",
+                        "c": 3
+                    },
+                    {
+                        "n": "internal",
+                        "c": 1
+                    }
+                ]
+            },
+            {
+                "n": "App_RoleGroupOverrides-GroupsDD-NIM_TEST",
+                "c": 3,
+                "childs": [
+                    {
+                        "n": "App_RoleGroupOverrides-GroupsDD-AD",
+                        "c": 3
+                    },
+                    {
+                        "n": "App_RoleGroupOverrides-GroupsDD-Google",
+                        "c": 3
+                    },
+                    {
+                        "n": "internal",
                         "c": 1
                     }
                 ]
@@ -5452,10 +5684,6 @@
                 "c": 3,
                 "childs": [
                     {
-                        "n": "App_RoleGroupOverrides-MembersPending-Google",
-                        "c": 3
-                    },
-                    {
                         "n": "internal",
                         "c": 1
                     },
@@ -5475,6 +5703,24 @@
                     },
                     {
                         "n": "Google",
+                        "c": 1
+                    }
+                ]
+            },
+            {
+                "n": "App_RoleGroupOverrides-MembersPending-NIM",
+                "c": 3,
+                "childs": [
+                    {
+                        "n": "App_RoleGroupOverrides-MembersPending-Google",
+                        "c": 3
+                    },
+                    {
+                        "n": "App_RoleGroupOverrides-MembersPending-AD",
+                        "c": 3
+                    },
+                    {
+                        "n": "internal",
                         "c": 1
                     }
                 ]
@@ -5584,14 +5830,24 @@
                         "c": 3
                     },
                     {
-                        "n": "App_RoleGroupOverrides-MembersPending-AD",
+                        "n": "App_RoleGroupOverrides-MembersPending-NIM",
                         "c": 3
+                    },
+                    {
+                        "n": "sitemap-solid.svg",
+                        "c": 40
                     }
                 ]
             },
             {
                 "n": "RoleGroupOverrides",
                 "c": 27,
+                "childs": [
+                ]
+            },
+            {
+                "n": "sitemap-solid.svg",
+                "c": 40,
                 "childs": [
                 ]
             }


### PR DESCRIPTION
Add support for Internal NIM Groups.  Set these as the base filters in the app since they will always be available.